### PR TITLE
Fix to first character being removed from each command

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports.start = function (options) {
     prompt: "> ",
     userGlobal: true,
     eval: function (code, context, file, cb) {
-      code = babel.transform( code.slice(1, code.length - 1) ).code;
+      code = babel.transform(code).code;
       defaultEval.call(this, code, context, file, cb);
     }
   };


### PR DESCRIPTION
This fixes the bug where the first character of each command is removed by the `.slice` command