### PR TITLE
allow any version of babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "minimist": "^1.2.0"
   },
   "peerDependencies": {
-    "babel-core": "^5.5.8"
+    "babel-core": "*"
   },
   "engines": {
     "node": "4.2.x"


### PR DESCRIPTION
other there is an `UNMET PEER DEPENDENCY` error message
